### PR TITLE
feat: Add Python Typer and Rust Clap CLI templates

### DIFF
--- a/docs/cli-tool-guide.md
+++ b/docs/cli-tool-guide.md
@@ -15,6 +15,7 @@
 *   **Backend**: Axum (Rust), NestJS (TS), FastAPI (Python)
 *   **Frontend**: Next.js (TS), Flutter (Dart)
 *   **Infrastructure**: Terraform (GCP, AWS)
+*   **CLI**: Typer (Python), Clap (Rust)
 
 ### 추가 사용 사례 (Additional Use Cases)
 *   Social platform scripts
@@ -25,8 +26,8 @@
 ## 3. 기능 (Features)
 
 ### `init` (초기화)
-*   **다양한 템플릿 유형 지원**: 코드 프로젝트(백엔드, 프론트엔드, 인프라), 스크립트, 문서(블로그, 기록) 등 다양한 유형의 템플릿을 기반으로 새 항목을 생성합니다.
-*   **세분화된 템플릿 선택**: 언어, 프레임워크, 콘텐츠 유형(예: `backend/python/fastapi`, `doc/obsidian/blog-post`)을 조합하여 템플릿을 선택할 수 있도록 지원합니다.
+*   **다양한 템플릿 유형 지원**: 코드 프로젝트(백엔드, 프론트엔드, 인프라, **CLI**), 스크립트, 문서(블로그, 기록) 등 다양한 유형의 템플릿을 기반으로 새 항목을 생성합니다.
+*   **세분화된 템플릿 선택**: 언어, 프레임워크, 콘텐츠 유형(예: `backend/python/fastapi`, `doc/obsidian/blog-post`, `cli/python/typer`)을 조합하여 템플릿을 선택할 수 있도록 지원합니다.
 *   특정 템플릿 버전을 선택할 수 있도록 지원합니다 (Git 태그 활용).
 *   프로젝트/항목 이름, 경로, 작성자 등 사용자 입력을 받습니다.
 *   템플릿 파일 복사 및 플레이스홀더(placeholder) 치환 기능을 포함합니다.
@@ -54,7 +55,7 @@ cli/
 *   **CLI 프레임워크 (CLI Framework):** `Typer` (또는 `Click`) 라이브러리를 사용하여 명령줄 인자 파싱, 하위 명령 정의, 도움말 생성 등을 처리합니다.
 *   **`template_manager.py`:**
     *   `agent-template` 저장소를 로컬에 클론하거나 업데이트하는 기능을 담당합니다.
-    *   사용 가능한 템플릿 디렉토리(예: `templates/backend/python/fastapi`, `templates/doc/obsidian/blog-post`)를 식별합니다.
+    *   사용 가능한 템플릿 디렉토리(예: `templates/backend/python/fastapi`, `templates/doc/obsidian/blog-post`, `templates/cli/python/typer`)를 식별합니다.
     *   Git 태그를 사용하여 템플릿의 버전을 관리하고, 특정 버전의 템플릿을 체크아웃하는 기능을 제공합니다.
 *   **`project_generator.py`:**
     *   선택된 템플릿 디렉토리의 내용을 새 프로젝트/콘텐츠 경로로 복사합니다.

--- a/templates/cli/python/typer/main.py
+++ b/templates/cli/python/typer/main.py
@@ -1,0 +1,15 @@
+# templates/cli/python/typer/main.py
+
+import typer
+
+app = typer.Typer()
+
+@app.command()
+def hello(name: str = "World"):
+    """
+    Say hello to NAME.
+    """
+    print(f"Hello {name}!")
+
+if __name__ == "__main__":
+    app()

--- a/templates/cli/python/typer/requirements.txt
+++ b/templates/cli/python/typer/requirements.txt
@@ -1,0 +1,4 @@
+# templates/cli/python/typer/requirements.txt
+
+typer==0.9.0
+"python-dotenv<1.0.0,>=0.21.0"

--- a/templates/cli/rust/clap/Cargo.toml
+++ b/templates/cli/rust/clap/Cargo.toml
@@ -1,0 +1,9 @@
+# templates/cli/rust/clap/Cargo.toml
+
+[package]
+name = "{{project_name | kebab_case}}"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+clap = { version = "4.0", features = ["derive"] }

--- a/templates/cli/rust/clap/src/main.rs
+++ b/templates/cli/rust/clap/src/main.rs
@@ -1,0 +1,24 @@
+# templates/cli/rust/clap/src/main.rs
+
+use clap::Parser;
+
+/// Simple program to greet a person
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    /// Name of the person to greet
+    #[arg(short, long)]
+    name: String,
+
+    /// Number of times to greet
+    #[arg(short, long, default_value_t = 1)]
+    count: u8,
+}
+
+fn main() {
+    let args = Args::parse();
+
+    for _ in 0..args.count {
+        println!("Hello {}!", args.name);
+    }
+}


### PR DESCRIPTION
## Summary / 요약
<!-- 새로운 기능의 핵심 내용을 3-5개 불릿 포인트로 요약 -->
<!-- Summarize the new feature in 3-5 bullet points -->
• Python Typer 및 Rust Clap CLI 템플릿을 추가했습니다. (Added Python Typer and Rust Clap CLI templates.)
• `templates/cli/python/typer` 및 `templates/cli/rust/clap` 디렉토리에 기본적인 CLI 프로젝트 구조를 포함했습니다. (Included basic CLI project structures in `templates/cli/python/typer` and `templates/cli/rust/clap` directories.)
• `docs/cli-tool-guide.md` 문서를 업데이트하여 새로운 CLI 템플릿 유형을 반영했습니다. (Updated `docs/cli-tool-guide.md` to reflect the new CLI template types.)

## Problem/Motivation / 문제 및 동기
<!-- 이 기능이 왜 필요한지, 어떤 사용자 문제를 해결하는지 설명 -->

**English:**
To support the creation of CLI tools using popular frameworks in Python and Rust, dedicated templates are needed. This PR provides these templates, streamlining the setup process for CLI projects.

**한국어:**
Python과 Rust에서 인기 있는 프레임워크를 사용하여 CLI 툴을 생성할 수 있도록 전용 템플릿이 필요합니다. 이 PR은 이러한 템플릿을 제공하여 CLI 프로젝트의 설정 프로세스를 간소화합니다.

## Solution / 해결방법
<!-- 기능을 어떻게 구현했는지, 주요 설계 결정사항 설명 -->

`templates/cli/python/typer` 디렉토리에는 `main.py`와 `requirements.txt`를 포함하여 Python Typer 기반 CLI 프로젝트의 기본 구조를 제공합니다. `templates/cli/rust/clap` 디렉토리에는 `Cargo.toml`과 `src/main.rs`를 포함하여 Rust Clap 기반 CLI 프로젝트의 기본 구조를 제공합니다. 또한, `docs/cli-tool-guide.md`를 업데이트하여 이 새로운 템플릿들을 문서화했습니다.

### Implementation Details / 구현 세부사항
```python
# templates/cli/python/typer/main.py (simplified)
import typer
app = typer.Typer()
@app.command()
def hello(name: str = "World"):
    print(f"Hello {name}!")
```
```rust
// templates/cli/rust/clap/src/main.rs (simplified)
use clap::Parser;
#[derive(Parser, Debug)]
struct Args { name: String, count: u8, }
fn main() {
    let args = Args::parse();
    for _ in 0..args.count {
        println!("Hello {}!", args.name);
    }
}
```

### API Changes / API 변경사항
```typescript
// 이 PR은 새로운 템플릿을 추가하며, 기존 API 변경사항은 없습니다.
// This PR adds new templates and does not involve changes to existing APIs.
```

## User Experience / 사용자 경험
<!-- 사용자 관점에서 어떻게 동작하는지 설명 -->
사용자는 CLI 툴을 통해 Python Typer 또는 Rust Clap 기반의 새로운 CLI 프로젝트를 쉽게 시작할 수 있게 됩니다. 이는 프로젝트 설정 시간을 단축하고 개발 효율성을 높일 것입니다.

## Test Plan
- [ ] 생성된 템플릿 프로젝트가 정상적으로 빌드 및 실행되는지 수동 확인.
- [ ] CLI 툴의 `init` 명령어를 통해 템플릿이 올바르게 복사되고 플레이스홀더가 치환되는지 확인 (향후 CLI 툴 구현 시).

## Screenshots/Demo
<!-- 새로운 기능의 스크린샷이나 데모 GIF 첨부 -->
N/A

## Performance Impact
<!-- 성능에 미치는 영향 분석 -->
N/A (새로운 템플릿 추가로 인한 성능 영향 없음)

## Breaking Changes
⚠️ 없음 (No breaking changes)

## Documentation
<!-- 업데이트된 문서나 새로 작성된 문서 링크 -->
- `docs/cli-tool-guide.md` 업데이트.

## Checklist
- [x] 기능 요구사항 충족 확인 (새로운 CLI 템플릿 추가)
- [x] 코드 스타일 가이드 준수
- [ ] 테스트 커버리지 80% 이상 (N/A)
- [ ] 사용자 문서 업데이트 (N/A, `docs/cli-tool-guide.md`에 포함)
- [ ] API 문서 업데이트 (N/A)
- [ ] 보안 검토 완료 (N/A)
